### PR TITLE
Added a config to limit the code-gen and class loading

### DIFF
--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGenerator.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGenerator.java
@@ -71,6 +71,11 @@ public class FastDeserializerGenerator<T> extends FastDeserializerGeneratorBase<
     super(useGenericTypes, writer, reader, destination, classLoader, compileClassPath);
   }
 
+  FastDeserializerGenerator(boolean useGenericTypes, Schema writer, Schema reader, File destination,
+      ClassLoader classLoader, String compileClassPath, int loadClassLimit) {
+    super(useGenericTypes, writer, reader, destination, classLoader, compileClassPath, loadClassLimit);
+  }
+
   public FastDeserializer<T> generateDeserializer() {
     String className = getClassName(writer, reader, useGenericTypes ? "Generic" : "Specific");
     JPackage classPackage = codeModel._package(generatedPackageName);

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGeneratorBase.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGeneratorBase.java
@@ -25,6 +25,13 @@ public abstract class FastDeserializerGeneratorBase<T> extends FastSerdeBase {
     this.reader = reader;
   }
 
+  FastDeserializerGeneratorBase(boolean useGenericTypes, Schema writer, Schema reader, File destination, ClassLoader classLoader,
+      String compileClassPath, int loadClassLimit) {
+    super("deserialization", useGenericTypes, Utf8.class, destination, classLoader, compileClassPath, false, loadClassLimit);
+    this.writer = writer;
+    this.reader = reader;
+  }
+
   protected static Symbol[] reverseSymbolArray(Symbol[] symbols) {
     Symbol[] reversedSymbols = new Symbol[symbols.length];
 

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastGenericDeserializerGenerator.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastGenericDeserializerGenerator.java
@@ -10,4 +10,9 @@ public final class FastGenericDeserializerGenerator<T> extends FastDeserializerG
       String compileClassPath) {
     super(true, writer, reader, destination, classLoader, compileClassPath);
   }
+
+  FastGenericDeserializerGenerator(Schema writer, Schema reader, File destination, ClassLoader classLoader,
+      String compileClassPath, int loadClassLimit) {
+    super(true, writer, reader, destination, classLoader, compileClassPath, loadClassLimit);
+  }
 }

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastGenericSerializerGenerator.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastGenericSerializerGenerator.java
@@ -10,4 +10,9 @@ public class FastGenericSerializerGenerator<T> extends FastSerializerGenerator<T
       String compileClassPath) {
     super(true, schema, destination, classLoader, compileClassPath);
   }
+
+  public FastGenericSerializerGenerator(Schema schema, File destination, ClassLoader classLoader,
+      String compileClassPath, int loadClassLimit) {
+    super(true, schema, destination, classLoader, compileClassPath, loadClassLimit);
+  }
 }

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSerdeBase.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSerdeBase.java
@@ -14,6 +14,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import javax.tools.JavaCompiler;
 import javax.tools.ToolProvider;
 import org.apache.avro.Schema;
@@ -32,6 +33,9 @@ public abstract class FastSerdeBase {
   protected static final String SEP = "_";
   public static final String GENERATED_PACKAGE_NAME_PREFIX = "com.linkedin.avro.fastserde.generated.";
 
+  private volatile int loadClassLimit = Integer.MAX_VALUE;
+  private int loadClassNum = 0;
+
   /**
    * A repository of how many times a given name was used.
    * N.B.: Does not actually need to be threadsafe, but it is made so just for defensive coding reasons.
@@ -46,6 +50,12 @@ public abstract class FastSerdeBase {
   protected final ClassLoader classLoader;
   protected final String compileClassPath;
   protected JDefinedClass generatedClass;
+
+  public FastSerdeBase(String description, boolean useGenericTypes, Class defaultStringClass, File destination, ClassLoader classLoader,
+      String compileClassPath, boolean isForSerializer, int loadClassLimit) {
+    this(description, useGenericTypes, defaultStringClass, destination, classLoader, compileClassPath, isForSerializer);
+    this.loadClassLimit = loadClassLimit;
+  }
 
   public FastSerdeBase(String description, boolean useGenericTypes, Class defaultStringClass, File destination, ClassLoader classLoader,
       String compileClassPath, boolean isForSerializer) {
@@ -136,6 +146,29 @@ public abstract class FastSerdeBase {
       throw new FastSerdeGeneratorException("Unable to compile:" + className + " from source file: " + filePath);
     }
 
-    return classLoader.loadClass(generatedPackageName + "." + className);
+    return loadClassWithLimit(() -> {
+      try {
+        return classLoader.loadClass(generatedPackageName + "." + className);
+      } catch (ClassNotFoundException e) {
+        throw new FastSerdeGeneratorException("Unable to load:" + className + " from source file: " + filePath, e);
+      }
+    });
+  }
+
+  /**
+   * A wrapper function that limits the total number of fast de/serializer classes loaded
+   *
+   * @param supplier The function to load fast de/serializer class
+   */
+  protected synchronized <T> T loadClassWithLimit(Supplier<T> supplier) {
+    if (this.loadClassNum < this.loadClassLimit) {
+      T classObj = null;
+      classObj = supplier.get();
+      this.loadClassNum++;
+      return classObj;
+    } else {
+      LOGGER.warn("Loaded fast serdes classes number {}, with limit set to {}", loadClassNum, loadClassLimit);
+    }
+    return null;
   }
 }

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSerializerGenerator.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSerializerGenerator.java
@@ -42,6 +42,12 @@ public class FastSerializerGenerator<T> extends FastSerdeBase {
     this.schema = schema;
   }
 
+  public FastSerializerGenerator(boolean useGenericTypes, Schema schema, File destination, ClassLoader classLoader,
+      String compileClassPath, int loadClassLimit) {
+    super("serialization", useGenericTypes, CharSequence.class, destination, classLoader, compileClassPath, true, loadClassLimit);
+    this.schema = schema;
+  }
+
   public static String getClassName(Schema schema, String description) {
     Long schemaId = Math.abs(Utils.getSchemaFingerprint(schema));
     String typeName = SchemaAssistant.getTypeName(schema);

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSpecificDeserializerGenerator.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSpecificDeserializerGenerator.java
@@ -10,4 +10,9 @@ public final class FastSpecificDeserializerGenerator<T> extends FastDeserializer
       String compileClassPath) {
     super(false, writer, reader, destination, classLoader, compileClassPath);
   }
+
+  FastSpecificDeserializerGenerator(Schema writer, Schema reader, File destination, ClassLoader classLoader,
+      String compileClassPath, int loadClassLimit) {
+    super(false, writer, reader, destination, classLoader, compileClassPath, loadClassLimit);
+  }
 }

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSpecificSerializerGenerator.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSpecificSerializerGenerator.java
@@ -10,4 +10,9 @@ public class FastSpecificSerializerGenerator<T> extends FastSerializerGenerator<
       String compileClassPath) {
     super(false, schema, destination, classLoader, compileClassPath);
   }
+
+  public FastSpecificSerializerGenerator(Schema schema, File destination, ClassLoader classLoader,
+      String compileClassPath, int loadClassLimit) {
+    super(false, schema, destination, classLoader, compileClassPath, loadClassLimit);
+  }
 }

--- a/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/FastDatumReaderTest.java
+++ b/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/FastDatumReaderTest.java
@@ -97,4 +97,51 @@ public class FastDatumReaderTest {
     Assert.assertEquals(new Utf8("test"),
         fastGenericDatumReader.read(null, FastSerdeTestsSupport.genericDataAsDecoder(record)).get("test"));
   }
+
+  @Test(groups = {"deserializationTest"})
+  @SuppressWarnings("unchecked")
+  public void shouldNotCreateFastDeserializerDueToLimit() throws IOException, InterruptedException {
+    // Set generatedFastSerDesLimit to 1
+    // Try to generate fast deserializer for the first schema
+    Schema recordSchema1 = createRecord("TestSchema1", createPrimitiveUnionFieldSchema("test", Schema.Type.STRING));
+    GenericRecord record1 = new GenericData.Record(recordSchema1);
+    record1.put("test", "test");
+
+    FastSerdeCache cacheLimit1 = new FastSerdeCache(Runnable::run, 1);
+    FastGenericDatumReader<GenericRecord> fastGenericDatumReader = new FastGenericDatumReader<>(recordSchema1, cacheLimit1);
+
+    // when
+    fastGenericDatumReader.read(null, FastSerdeTestsSupport.genericDataAsDecoder(record1));
+
+    // then
+    FastDeserializer<GenericRecord> fastGenericDeserializer =
+        (FastDeserializer<GenericRecord>) cacheLimit1.getFastGenericDeserializer(recordSchema1, recordSchema1);
+
+    fastGenericDeserializer =
+        (FastDeserializer<GenericRecord>) cacheLimit1.getFastGenericDeserializer(recordSchema1, recordSchema1);
+
+    Assert.assertNotNull(fastGenericDeserializer);
+    Assert.assertNotEquals(1, fastGenericDeserializer.getClass().getDeclaredMethods().length);
+    Assert.assertEquals(new Utf8("test"),
+        fastGenericDatumReader.read(null, FastSerdeTestsSupport.genericDataAsDecoder(record1)).get("test"));
+
+    // Try to generate fast deserializer for the second schema
+    // Verify only return FastDeserializerWithAvroGenericImpl
+    Schema recordSchema2 = createRecord("TestSchema2", createPrimitiveUnionFieldSchema("test", Schema.Type.STRING));
+    GenericRecord record2 = new GenericData.Record(recordSchema2);
+    record2.put("test", "test");
+
+    // when
+    fastGenericDatumReader.read(null, FastSerdeTestsSupport.genericDataAsDecoder(record2));
+
+    // then
+    FastDeserializer<GenericRecord> fastGenericDeserializer2 =
+        (FastDeserializer<GenericRecord>) cacheLimit1.getFastGenericDeserializer(recordSchema2, recordSchema2);
+
+    fastGenericDeserializer2 =
+        (FastDeserializer<GenericRecord>) cacheLimit1.getFastGenericDeserializer(recordSchema2, recordSchema2);
+
+    Assert.assertNotNull(fastGenericDeserializer2);
+    Assert.assertEquals(1, fastGenericDeserializer2.getClass().getDeclaredMethods().length);
+  }
 }


### PR DESCRIPTION
The config sets the maximum number of fast SerDes classes
generated and loaded. It helps to limit the metaspace and codecache
usage brought by fast-avro runtime code-gen and class loading.

The limit config can be set via FastSerdeCache constructors.